### PR TITLE
Support embedding in arm64 binary

### DIFF
--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -23,8 +23,8 @@ func EmbedReleaseDataInBinary(binPath string, releasePath string, outputPath str
 		return fmt.Errorf("failed to read binary: %w", err)
 	}
 
-	start := bytes.Index(binContent, beginReleaseDelimiterBytes())
-	end := bytes.Index(binContent, endReleaseDelimiterBytes())
+	start := bytes.LastIndex(binContent, beginReleaseDelimiterBytes())
+	end := bytes.LastIndex(binContent, endReleaseDelimiterBytes())
 
 	if start != -1 && end != -1 {
 		// some release data is already embedded in the binary, remove it
@@ -82,12 +82,12 @@ func ExtractReleaseDataFromBinary(exe string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to read executable: %w", err)
 	}
 
-	start := bytes.Index(binContent, beginReleaseDelimiterBytes())
+	start := bytes.LastIndex(binContent, beginReleaseDelimiterBytes())
 	if start == -1 {
 		return nil, nil
 	}
 
-	end := bytes.Index(binContent, endReleaseDelimiterBytes())
+	end := bytes.LastIndex(binContent, endReleaseDelimiterBytes())
 	if end == -1 {
 		return nil, fmt.Errorf("failed to find end delimiter in executable")
 	}

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -23,11 +23,12 @@ func EmbedReleaseDataInBinary(binPath string, releasePath string, outputPath str
 		return fmt.Errorf("failed to read binary: %w", err)
 	}
 
-	start := bytes.LastIndex(binContent, beginReleaseDelimiterBytes())
-	end := bytes.LastIndex(binContent, endReleaseDelimiterBytes())
-
-	if start != -1 && end != -1 {
-		// some release data is already embedded in the binary, remove it
+	// in arm64 binaries, the delimiters will already be part of the binary content in plain text,
+	// so we need to check if the binary content _ends_ with the end delimiter in order to
+	// to determine if a release data is already embedded in the binary.
+	if bytes.HasSuffix(binContent, endReleaseDelimiterBytes()) {
+		start := bytes.LastIndex(binContent, beginReleaseDelimiterBytes())
+		end := bytes.LastIndex(binContent, endReleaseDelimiterBytes())
 		binContent = append(binContent[:start], binContent[end+len(endReleaseDelimiterBytes()):]...)
 	}
 

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -25,7 +25,7 @@ func EmbedReleaseDataInBinary(binPath string, releasePath string, outputPath str
 
 	// in arm64 binaries, the delimiters will already be part of the binary content in plain text,
 	// so we need to check if the binary content _ends_ with the end delimiter in order to
-	// to determine if a release data is already embedded in the binary.
+	// determine if a release data is already embedded in the binary.
 	if bytes.HasSuffix(binContent, endReleaseDelimiterBytes()) {
 		start := bytes.LastIndex(binContent, beginReleaseDelimiterBytes())
 		end := bytes.LastIndex(binContent, endReleaseDelimiterBytes())


### PR DESCRIPTION
in arm64 binaries, the delimiters will already be part of the binary content in plain text, so we need to check if the binary content _ends_ with the end delimiter in order to determine if a release data is already embedded in the binary, and use `LastIndex` to get the index of the embedded release data at the end.